### PR TITLE
[spm]: Handle enabled/disabled action for generated/transient units

### DIFF
--- a/sonic_package_manager/logger.py
+++ b/sonic_package_manager/logger.py
@@ -2,9 +2,10 @@
 
 """ Logger for sonic-package-manager. """
 
-import logging.handlers
-
+import logging
 import click_log
+
+from logging.handlers import SysLogHandler
 
 
 class Formatter(click_log.ColorFormatter):
@@ -25,5 +26,8 @@ log.setLevel(logging.INFO)
 click_handler = click_log.ClickHandler()
 click_handler.formatter = Formatter()
 
+syslog_handler = SysLogHandler()
+syslog_handler.setFormatter(logging.Formatter('%(name)s: %(message)s'))
+
 log.addHandler(click_handler)
-log.addHandler(logging.handlers.SysLogHandler())
+log.addHandler(syslog_handler)

--- a/sonic_package_manager/manager.py
+++ b/sonic_package_manager/manager.py
@@ -4,6 +4,7 @@ import contextlib
 import functools
 import os
 import pkgutil
+import subprocess
 import tempfile
 import yang as ly
 from inspect import signature
@@ -1023,6 +1024,31 @@ class PackageManager:
         self._systemctl_action(package, 'enable')
         self._systemctl_action(package, 'start')
 
+    @staticmethod
+    def _systemctl_is_generated_or_transient(unit_name: str) -> bool:
+        """Returns True if systemd considers the unit generated/transient.
+
+        On some platforms, SONiC's systemd generator
+        may materialize unit files under /run/systemd/generator.
+        Such units cannot be enabled/disabled persistently.
+        """
+        try:
+            proc = subprocess.run(
+                ['systemctl', 'is-enabled', unit_name],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+        except subprocess.TimeoutExpired as err:
+            log.warning(f'systemctl is-enabled timed out for unit {unit_name}: timeout={err.timeout}s')
+            return False
+        except Exception as err:
+            log.error(f'systemctl is-enabled failed for unit {unit_name}: {err}')
+            return False
+
+        state = (proc.stdout or '').strip().lower()
+        return state in ('generated', 'transient')
+
     def _systemctl_action(self, package: Package, action: str):
         """ Execute systemctl action for a service. """
 
@@ -1034,10 +1060,17 @@ class PackageManager:
         single_instance = host_service or (asic_service and not self.is_multi_npu)
         multi_instance = asic_service and self.is_multi_npu
         if single_instance:
-            run_command(['systemctl', action, name])
+            if action in ('enable', 'disable') and self._systemctl_is_generated_or_transient(name):
+                log.warning(f'Skipping systemctl {action} for generated/transient unit {name}')
+            else:
+                run_command(['systemctl', action, name])
         if multi_instance:
             for npu in range(self.num_npus):
-                run_command(['systemctl', action, f'{name}@{npu}'])
+                inst_name = f'{name}@{npu}'
+                if action in ('enable', 'disable') and self._systemctl_is_generated_or_transient(inst_name):
+                    log.warning(f'Skipping systemctl {action} for generated/transient unit {inst_name}')
+                else:
+                    run_command(['systemctl', action, inst_name])
 
     def _disable_feature(self, package: Package, block: bool = True):
         """ Stops the feature and blocks till operation is finished if


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

ERR log:
```
root@sonic:/home/admin# sudo sonic-package-manager install -y cpu-report==2.0.0
Execute systemctl action stop on cpu-report service
Execute systemctl action disable on cpu-report service
removed /usr/lib/systemd/system/cpu-report.service
removed /usr/local/bin/cpu-report.sh
removed /usr/bin/cpu-report.sh
removed /etc/sonic/cpu-report_reconcile
removed /etc/systemd/system/cpu-report.service.d
generated /usr/bin/cpu-report.sh
generated /usr/local/bin/cpu-report.sh
generated /usr/lib/systemd/system/cpu-report.service
cpu-report entry is added to AUTO_TECHSUPPORT_FEATURE table
Execute systemctl action enable on cpu-report service
Failed to enable unit: Unit /run/systemd/generator/cpu-report.service is transient or generated
cpu-report entry is added to AUTO_TECHSUPPORT_FEATURE table
removed /usr/lib/systemd/system/cpu-report.service
removed /usr/local/bin/cpu-report.sh
removed /usr/bin/cpu-report.sh
removed /etc/sonic/cpu-report_reconcile
removed /etc/systemd/system/cpu-report.service.d
generated /usr/bin/cpu-report.sh
generated /usr/local/bin/cpu-report.sh
generated /usr/lib/systemd/system/cpu-report.service
Execute systemctl action enable on cpu-report service
Failed to enable unit: Unit /run/systemd/generator/cpu-report.service is transient or generated
error: failed in rollback: Failed to execute "['systemctl', 'enable', 'cpu-report']"
Failed to install cpu-report==2.0.0: Failed to upgrade cpu-report: Failed to execute "['systemctl', 'enable', 'cpu-report']"
```

**Steps to reproduce:**

1. Add app repository
```
sudo sonic-package-manager repository add <app> <repo_url> --default-reference=1.0.0
```

2. Install app v1.0.0
```
sudo sonic-package-manager install <app>==1.0.0 -y
```

3. Enable the feature and wait for container to come up
```
sudo config feature state <app> enabled
```

4. Upgrade to v2.0.0 — THIS triggers the bug
```
sudo sonic-package-manager install -y <app>==2.0.0
```

**Sample:**

SHELL:
```
root@sonic:/home/admin# sonic-package-manager install cpu-report==2.0.0 -y
Execute systemctl action stop on cpu-report service
Execute systemctl action disable on cpu-report service
warning: Skipping systemctl disable for generated/transient unit cpu-report
removed /usr/lib/systemd/system/cpu-report.service
removed /usr/local/bin/cpu-report.sh
removed /usr/bin/cpu-report.sh
removed /etc/sonic/cpu-report_reconcile
removed /etc/systemd/system/cpu-report.service.d
generated /usr/bin/cpu-report.sh
generated /usr/local/bin/cpu-report.sh
generated /usr/lib/systemd/system/cpu-report.service
cpu-report entry is added to AUTO_TECHSUPPORT_FEATURE table
Execute systemctl action enable on cpu-report service
warning: Skipping systemctl enable for generated/transient unit cpu-report
Execute systemctl action start on cpu-report service
```

SYSLOG:
```
2026 Feb 10 16:18:55.531288 sonic INFO sonic-package-manager: Execute systemctl action disable on cpu-report service
2026 Feb 10 16:18:55.541984 sonic WARNING sonic-package-manager: Skipping systemctl disable for generated/transient unit cpu-report
2026 Feb 10 16:18:55.542262 sonic INFO sonic-package-manager: removed /usr/lib/systemd/system/cpu-report.service
2026 Feb 10 16:18:55.542481 sonic INFO sonic-package-manager: removed /usr/local/bin/cpu-report.sh
2026 Feb 10 16:18:55.542676 sonic INFO sonic-package-manager: removed /usr/bin/cpu-report.sh
2026 Feb 10 16:18:55.542861 sonic INFO sonic-package-manager: removed /etc/sonic/cpu-report_reconcile
2026 Feb 10 16:18:55.543674 sonic INFO sonic-package-manager: removed /etc/systemd/system/cpu-report.service.d
2026 Feb 10 16:18:56.190582 sonic INFO sonic-package-manager: generated /usr/bin/cpu-report.sh
2026 Feb 10 16:18:56.201750 sonic INFO sonic-package-manager: generated /usr/local/bin/cpu-report.sh
2026 Feb 10 16:18:56.218809 sonic INFO sonic-package-manager: generated /usr/lib/systemd/system/cpu-report.service
2026 Feb 10 16:18:56.894541 sonic INFO sonic-package-manager: cpu-report entry is added to AUTO_TECHSUPPORT_FEATURE table
2026 Feb 10 16:18:56.894689 sonic INFO sonic-package-manager: Execute systemctl action enable on cpu-report service
2026 Feb 10 16:18:56.905258 sonic WARNING sonic-package-manager: Skipping systemctl enable for generated/transient unit cpu-report
2026 Feb 10 16:18:56.905380 sonic INFO sonic-package-manager: Execute systemctl action start on cpu-report service
```

System logger fix also resolves the issue of missing application tag and very first word of the message:
```
2026 Feb 10 14:31:39.193944 sonic WARNING systemctl enable for generated/transient unit cpu-report
```

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

